### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,4 +1,6 @@
 name: CI/CD Pipeline
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/my-stellar-trail/my-stellar-trail/security/code-scanning/1](https://github.com/my-stellar-trail/my-stellar-trail/security/code-scanning/1)

To fix this issue, you should add a `permissions` block to the workflow or to the affected job. Since there is only one job (`build`) and no evidence of needing write access, it is best to assign the least privilege necessary. The minimal starting point is `contents: read`, which allows jobs to read repository contents without broader write access. This block can be added either at the root of the workflow (applies to all jobs) or directly under the job definition (if different jobs need different permissions). In this case, adding it to the job is fine, but adding at the root makes it clearer and applies to all jobs. No change to workflow functionality is required—just add `permissions: contents: read` at an appropriate location.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
